### PR TITLE
Allow variable tile size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,30 @@
-var merc = new (require('sphericalmercator'))();
+var SphericalMercator = require('sphericalmercator');
+
+// The SphericalMercator library only accepts a variable
+// tileSize on instantiation, which it uses to pre-cache
+// calculations by zoom level.
+// We cache each instantiation, keyed by tile size, to avoid
+// repeating this cost when working with a single tile size
+// (assumed to be the most-common use case).
+var smCache = {};
 
 module.exports.viewport = viewport;
 module.exports.bounds = bounds;
 
-function viewport(bounds, dimensions, minzoom, maxzoom) {
+function fetchMerc(tileSize) {
+    tileSize = tileSize || 256;
+
+    if (!smCache[tileSize]) {
+        smCache[tileSize] = new SphericalMercator({ size: tileSize });
+    }
+
+    return smCache[tileSize];
+};
+
+function viewport(bounds, dimensions, minzoom, maxzoom, tileSize) {
     minzoom = (minzoom === undefined) ? 0 : minzoom;
     maxzoom = (maxzoom === undefined) ? 20 : maxzoom;
-
+    var merc = fetchMerc(tileSize);
     var base = maxzoom,
         bl = merc.px([bounds[0], bounds[1]], base),
         tr = merc.px([bounds[2], bounds[3]], base),
@@ -22,13 +40,15 @@ function viewport(bounds, dimensions, minzoom, maxzoom) {
     return { center: center, zoom: zoom };
 }
 
-function bounds(viewport, zoom, dimensions) {
+function bounds(viewport, zoom, dimensions, tileSize) {
     if (viewport.lon !== undefined) {
         viewport = [
             viewport.lon,
             viewport.lat
         ];
     }
+
+    var merc = fetchMerc(tileSize);
     var px = merc.px(viewport, zoom);
     var tl = merc.ll([
         px[0] - (dimensions[0] / 2),

--- a/test/viewport.js
+++ b/test/viewport.js
@@ -44,3 +44,12 @@ test('viewport', function(t) {
 
     t.end();
 });
+
+test('bounds for 512px tiles', function(t) {
+    t.deepEqual(
+        viewport.bounds([-77.036556, 38.897708], 17, [1080, 350], 512),
+        [-77.03945338726044, 38.89697827424865, -77.03365981578827, 38.89843950894583]
+    );
+
+    t.end();
+});


### PR DESCRIPTION
This PR aims to resolve the zoom-related bug described in https://github.com/mapbox/geo-viewport/issues/3.

The initial commit provides a failing test for `viewport.bounds()`, to demonstrate the bug.