### PR TITLE
Use mapbox namespace for sphericalmercator

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   }, 
   "version": "0.2.1", 
   "dependencies": {
-    "sphericalmercator": "~1.0.2"
+    "@mapbox/sphericalmercator": "~1.0.2"
   }, 
   "scripts": {
     "test": "tap test/*.js", 


### PR DESCRIPTION
Prevents `npm` warning upon install of `geojson-viewport`:
```
npm WARN deprecated sphericalmercator@1.0.5: This module is now under the @mapbox namespace: install @mapbox/sphericalmercator instead
```