### PR TITLE
Changed to mapbox namespace, added CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## v0.2.2
+
+* Updated spherical mercator dependency to @mapbox namespace
+* Changed package to @mapbox namespace

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var SphericalMercator = require('sphericalmercator');
+var SphericalMercator = require('@mapbox/sphericalmercator');
 
 // The SphericalMercator library only accepts a variable
 // tileSize on instantiation, which it uses to pre-cache

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "BSD-2-Clause", 
-  "name": "geo-viewport", 
+  "name": "@mapbox/geo-viewport", 
   "repository": {
     "url": "git@github.com:mapbox/geo-viewport.git", 
     "type": "git"
@@ -9,9 +9,9 @@
   "bugs": {
     "url": "https://github.com/mapbox/geo-viewport/issues"
   }, 
-  "version": "0.2.1", 
+  "version": "0.2.2", 
   "dependencies": {
-    "sphericalmercator": "~1.0.2"
+    "@mapbox/sphericalmercator": "~1.0.2"
   }, 
   "scripts": {
     "test": "tap test/*.js", 


### PR DESCRIPTION
/cc @mapsam 

- [ ] Run `npm publish --access=public` to publish the first namespaced version
- [ ] Run `npm deprecate geo-viewport "This module has moved: please install @mapbox/geo-viewport instead"`