### PR TITLE
Fixes issue #22 by correcting the viewport's center point calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,18 +33,20 @@ function viewport(bounds, dimensions, minzoom, maxzoom, tileSize, allowFloat) {
     minzoom = (minzoom === undefined) ? 0 : minzoom;
     maxzoom = (maxzoom === undefined) ? 20 : maxzoom;
     var merc = fetchMerc(tileSize);
-    var base = maxzoom,
-        bl = merc.px([bounds[0], bounds[1]], base),
-        tr = merc.px([bounds[2], bounds[3]], base),
-        width = tr[0] - bl[0],
-        height = bl[1] - tr[1],
-        ratios = [width / dimensions[0], height / dimensions[1]],
-        adjusted = getAdjusted(base, ratios, allowFloat);
+    var base = maxzoom;
+    var bl = merc.px([bounds[0], bounds[1]], base);
+    var tr = merc.px([bounds[2], bounds[3]], base);
+    var width = tr[0] - bl[0];
+    var height = bl[1] - tr[1];
+    var centerPixelX = bl[0] + (width / 2);
+    var centerPixelY = tr[1] + (height / 2);
+    var ratios = [width / dimensions[0], height / dimensions[1]];
+    var adjusted = getAdjusted(base, ratios, allowFloat);
 
-    return {
-        center: merc.ll([(bl[0] + width / 2), (tr[1] + height / 2)], base),
-        zoom: Math.max(minzoom, Math.min(maxzoom, adjusted))
-    };
+    var center = merc.ll([centerPixelX, centerPixelY], base);
+    var zoom = Math.max(minzoom, Math.min(maxzoom, adjusted));
+
+    return { center, zoom };
 }
 
 function bounds(viewport, zoom, dimensions, tileSize) {

--- a/index.js
+++ b/index.js
@@ -23,9 +23,9 @@ function fetchMerc(tileSize) {
 
 function getAdjusted(base, ratios, allowFloat) {
     var adjusted = Math.min(
-            base - (Math.log(ratios[0]) / Math.log(2)),
-            base - (Math.log(ratios[1]) / Math.log(2)));
-    
+        base - (Math.log(ratios[0]) / Math.log(2)),
+        base - (Math.log(ratios[1]) / Math.log(2)));
+
     return allowFloat ? adjusted : Math.floor(adjusted);
 }
 
@@ -39,11 +39,12 @@ function viewport(bounds, dimensions, minzoom, maxzoom, tileSize, allowFloat) {
         width = tr[0] - bl[0],
         height = bl[1] - tr[1],
         ratios = [width / dimensions[0], height / dimensions[1]],
-        center = [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2],
-        adjusted = getAdjusted(base, ratios, allowFloat),
-        zoom = Math.max(minzoom, Math.min(maxzoom, adjusted));
+        adjusted = getAdjusted(base, ratios, allowFloat);
 
-    return { center: center, zoom: zoom };
+    return {
+        center: merc.ll([(bl[0] + width / 2), (tr[1] + height / 2)], base),
+        zoom: Math.max(minzoom, Math.min(maxzoom, adjusted))
+    };
 }
 
 function bounds(viewport, zoom, dimensions, tileSize) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geo-viewport",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/mapbox/geo-viewport/issues"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "dependencies": {
     "@mapbox/sphericalmercator": "~1.1.0"
   },

--- a/test/viewport.js
+++ b/test/viewport.js
@@ -9,43 +9,31 @@ function precisionRound(number, precision) {
     return Math.round(number * factor) / factor;
 }
 
+const sampleBounds = [
+    5.668343999999995,
+    45.111511000000014,
+    5.852471999999996,
+    45.26800200000002
+];
+
+const expectedCenter = [
+    5.760407969355583,
+    45.189810341718136
+];
+
 test('viewport', function(t) {
-    t.deepEqual(viewport.viewport([
-        5.668343999999995,
-        45.111511000000014,
-        5.852471999999996,
-        45.26800200000002
-    ], [640, 480]), {
-        center: [
-            5.760407969355583,
-            45.189810341718136
-        ],
+    t.deepEqual(viewport.viewport(sampleBounds, [640, 480]), {
+        center: expectedCenter,
         zoom: 11
     });
 
-    t.deepEqual(viewport.viewport([
-        5.668343999999995,
-        45.111511000000014,
-        5.852471999999996,
-        45.26800200000002
-    ], [64, 48]), {
-        center: [
-            5.760407969355583,
-            45.189810341718136
-        ],
+    t.deepEqual(viewport.viewport(sampleBounds, [64, 48]), {
+        center: expectedCenter,
         zoom: 8
     });
 
-    t.deepEqual(viewport.viewport([
-        5.668343999999995,
-        45.111511000000014,
-        5.852471999999996,
-        45.26800200000002
-    ], [10, 10]), {
-        center: [
-            5.760407969355583,
-            45.189810341718136
-        ],
+    t.deepEqual(viewport.viewport(sampleBounds, [10, 10]), {
+        center: expectedCenter,
         zoom: 5
     });
 
@@ -82,16 +70,8 @@ test('bounds for float zooms', function(t) {
 });
 
 test('viewport for float zooms', function(t) {
-    t.deepEqual(viewport.viewport([
-        5.668343999999995,
-        45.111511000000014,
-        5.852471999999996,
-        45.26800200000002
-    ], [10, 10], undefined, undefined, 256, true), {
-        center: [
-            5.760407969355583,
-            45.189810341718136
-        ],
+    t.deepEqual(viewport.viewport(sampleBounds, [10, 10], undefined, undefined, 256, true), {
+        center: expectedCenter,
         zoom: 5.984828902182182
     });
 

--- a/test/viewport.js
+++ b/test/viewport.js
@@ -40,6 +40,26 @@ test('viewport', function(t) {
     t.end();
 });
 
+test('viewport in Southern hemisphere', function(t) {
+    t.deepEqual(viewport.viewport([10, -20, 20, -10], [500, 250]), {
+        center: [
+            14.999999776482582,
+            -15.058651551491899
+        ],
+        zoom: 5
+    });
+
+    t.deepEqual(viewport.viewport([-10, -60, 10, -30], [500, 250]), {
+        center: [
+            0,
+            -47.05859720188612
+        ],
+        zoom: 2
+    });
+
+    t.end();
+});
+
 test('bounds for 512px tiles', function(t) {
     var bounds = viewport.bounds([-77.036556, 38.897708], 17, [1080, 350], 512);
     var xMin = bounds[0];

--- a/test/viewport.js
+++ b/test/viewport.js
@@ -57,8 +57,8 @@ test('viewport in Southern hemisphere', function(t) {
     ));
 
     t.ok(areViewportsApproximatelyEqual(
-        viewport.viewport([-10, -50, 10, -30], [500, 250]),
-        { center: [0, -40.74575679866635], zoom: 3 }
+        viewport.viewport([-10, -60, 10, -30], [500, 250]),
+        { center: [0, -47.05859720188612], zoom: 2 }
     ));
 
     t.end();

--- a/test/viewport.js
+++ b/test/viewport.js
@@ -49,12 +49,12 @@ test('viewport in Southern hemisphere', function(t) {
         zoom: 5
     });
 
-    t.deepEqual(viewport.viewport([-10, -60, 10, -30], [500, 250]), {
+    t.deepEqual(viewport.viewport([-10, -50, 10, -30], [500, 250]), {
         center: [
             0,
-            -47.05859720188612
+            -40.74575679866635
         ],
-        zoom: 2
+        zoom: 3
     });
 
     t.end();

--- a/test/viewport.js
+++ b/test/viewport.js
@@ -9,8 +9,7 @@ function precisionRound(number, precision) {
     return Math.round(number * factor) / factor;
 }
 
-test('viewport', function (t) {
-
+test('viewport', function(t) {
     t.deepEqual(viewport.viewport([
         5.668343999999995,
         45.111511000000014,
@@ -18,8 +17,8 @@ test('viewport', function (t) {
         45.26800200000002
     ], [640, 480]), {
         center: [
-            5.7604079999999955,
-            45.189756500000016
+            5.760407969355583,
+            45.189810341718136
         ],
         zoom: 11
     });
@@ -31,8 +30,8 @@ test('viewport', function (t) {
         45.26800200000002
     ], [64, 48]), {
         center: [
-            5.7604079999999955,
-            45.189756500000016
+            5.760407969355583,
+            45.189810341718136
         ],
         zoom: 8
     });
@@ -44,8 +43,8 @@ test('viewport', function (t) {
         45.26800200000002
     ], [10, 10]), {
         center: [
-            5.7604079999999955,
-            45.189756500000016
+            5.760407969355583,
+            45.189810341718136
         ],
         zoom: 5
     });
@@ -53,7 +52,7 @@ test('viewport', function (t) {
     t.end();
 });
 
-test('bounds for 512px tiles', function (t) {
+test('bounds for 512px tiles', function(t) {
     var bounds = viewport.bounds([-77.036556, 38.897708], 17, [1080, 350], 512);
     var xMin = bounds[0];
     var yMin = bounds[1];
@@ -67,19 +66,19 @@ test('bounds for 512px tiles', function (t) {
     t.end();
 });
 
-test('bounds for float zooms', function (t) {
-  var zoom = 16.52;
-  var bounds = viewport.bounds([-77.036556, 38.897708], zoom, [1080, 350], 512);
-  var xMin = bounds[0];
-  var yMin = bounds[1];
-  var xMax = bounds[2];
-  var yMax = bounds[3];
+test('bounds for float zooms', function(t) {
+    var zoom = 16.52;
+    var bounds = viewport.bounds([-77.036556, 38.897708], zoom, [1080, 350], 512);
+    var xMin = bounds[0];
+    var yMin = bounds[1];
+    var xMax = bounds[2];
+    var yMax = bounds[3];
 
-  t.equal(precisionRound(xMin, decDegreesFloatTolerance), -77.04059627);
-  t.equal(precisionRound(yMin, decDegreesFloatTolerance), 38.89668897);
-  t.equal(precisionRound(xMax, decDegreesFloatTolerance), -77.03251573);
-  t.equal(precisionRound(yMax, decDegreesFloatTolerance), 38.89872702);
-  t.end();
+    t.equal(precisionRound(xMin, decDegreesFloatTolerance), -77.04059627);
+    t.equal(precisionRound(yMin, decDegreesFloatTolerance), 38.89668897);
+    t.equal(precisionRound(xMax, decDegreesFloatTolerance), -77.03251573);
+    t.equal(precisionRound(yMax, decDegreesFloatTolerance), 38.89872702);
+    t.end();
 });
 
 test('viewport for float zooms', function(t) {
@@ -90,11 +89,11 @@ test('viewport for float zooms', function(t) {
         45.26800200000002
     ], [10, 10], undefined, undefined, 256, true), {
         center: [
-            5.7604079999999955,
-            45.189756500000016
+            5.760407969355583,
+            45.189810341718136
         ],
         zoom: 5.984828902182182
     });
-    
+
     t.end();
 });

--- a/test/viewport.js
+++ b/test/viewport.js
@@ -21,41 +21,45 @@ const expectedCenter = [
     45.189810341718136
 ];
 
+function isApproximatelyEqual(a, b) {
+    return Math.abs(a - b) < 1e-10;
+}
+
+function areViewportsApproximatelyEqual(v1, v2) {
+    return isApproximatelyEqual(v1.center[0], v2.center[0]) &&
+        isApproximatelyEqual(v1.center[1], v2.center[1]) &&
+        isApproximatelyEqual(v1.zoom, v2.zoom);
+}
+
 test('viewport', function(t) {
-    t.deepEqual(viewport.viewport(sampleBounds, [640, 480]), {
-        center: expectedCenter,
-        zoom: 11
-    });
+    t.ok(areViewportsApproximatelyEqual(
+        viewport.viewport(sampleBounds, [640, 480]),
+        { center: expectedCenter, zoom: 11 }
+    ));
 
-    t.deepEqual(viewport.viewport(sampleBounds, [64, 48]), {
-        center: expectedCenter,
-        zoom: 8
-    });
+    t.ok(areViewportsApproximatelyEqual(
+        viewport.viewport(sampleBounds, [64, 48]),
+        { center: expectedCenter, zoom: 8 }
+    ));
 
-    t.deepEqual(viewport.viewport(sampleBounds, [10, 10]), {
-        center: expectedCenter,
-        zoom: 5
-    });
+    t.ok(areViewportsApproximatelyEqual(
+        viewport.viewport(sampleBounds, [10, 10]),
+        { center: expectedCenter, zoom: 5 }
+    ));
 
     t.end();
 });
 
 test('viewport in Southern hemisphere', function(t) {
-    t.deepEqual(viewport.viewport([10, -20, 20, -10], [500, 250]), {
-        center: [
-            14.999999776482582,
-            -15.058651551491899
-        ],
-        zoom: 5
-    });
+    t.ok(areViewportsApproximatelyEqual(
+        viewport.viewport([10, -20, 20, -10], [500, 250]),
+        { center: [14.999999776482582, -15.058651551491899], zoom: 5 }
+    ));
 
-    t.deepEqual(viewport.viewport([-10, -50, 10, -30], [500, 250]), {
-        center: [
-            0,
-            -40.74575679866635
-        ],
-        zoom: 3
-    });
+    t.ok(areViewportsApproximatelyEqual(
+        viewport.viewport([-10, -50, 10, -30], [500, 250]),
+        { center: [0, -40.74575679866635], zoom: 3 }
+    ));
 
     t.end();
 });
@@ -90,10 +94,10 @@ test('bounds for float zooms', function(t) {
 });
 
 test('viewport for float zooms', function(t) {
-    t.deepEqual(viewport.viewport(sampleBounds, [10, 10], undefined, undefined, 256, true), {
-        center: expectedCenter,
-        zoom: 5.984828902182182
-    });
+    t.ok(areViewportsApproximatelyEqual(
+        viewport.viewport(sampleBounds, [10, 10], undefined, undefined, 256, true),
+        { center: expectedCenter, zoom: 5.984828902182182 }
+    ));
 
     t.end();
 });


### PR DESCRIPTION
Resolves https://github.com/mapbox/geo-viewport/issues/22 by setting the viewport's center based on spherical mercator coordinates instead of planar arithmetic. This PR also adds a couple tests that depict how the center's latitude is not halfway between its bounds in planar arithmetic, but rather a latitude closer to the Earth's poles.