### PR TITLE
Tests against Node v10, v12, and v14 and hooks into codecov.io for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
-  - 6
-  - 8
-sudo: false
+  - 10
+  - 12
+  - 14
+script:
+  - npm test
+after_script:
+  - npm run upload-coverage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/mapbox/geo-viewport.svg)](https://travis-ci.com/mapbox/geo-viewport)
+[![Build Status](https://travis-ci.com/mapbox/geo-viewport.svg)](https://travis-ci.com/mapbox/geo-viewport) [![codecov](https://codecov.io/gh/mapbox/geo-viewport/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/geo-viewport)
 
 # geo-viewport
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,343 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/core": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
+      "integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.10",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.5",
+        "@babel/parser": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.10",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.10.tgz",
+      "integrity": "sha512-6mCdfhWgmqLdtTkhXjnIz0LcdVCd26wS2JXRtj2XY0u5klDsXBREA/pG5NVOuVnF2LUrBGNFtQkIqqTbblg0ww==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.10",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+      "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.10"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+      "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.7"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+      "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.10"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+      "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
+      "integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
+      "integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.10",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.12.10",
+        "@babel/types": "^7.12.10",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
+      "integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
+    },
     "@mapbox/sphericalmercator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz",
       "integrity": "sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA=="
+    },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
     },
     "JSONStream": {
       "version": "1.3.2",
@@ -25,6 +358,42 @@
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
       "dev": true
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -37,6 +406,21 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^3.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
@@ -45,6 +429,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
     },
     "array-filter": {
       "version": "0.0.1",
@@ -406,6 +796,24 @@
       "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
       "dev": true
     },
+    "caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "requires": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "caseless": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
@@ -443,11 +851,82 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "clean-yaml-object": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
       "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
       "dev": true
+    },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
+    "codecov": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.1.tgz",
+      "integrity": "sha512-Qm7ltx1pzLPsliZY81jyaQ80dcNR4/JpcX0IHCIWrHBXgseySqbdbYfkdiXd7o/xmzQpGRVCKGYeTrHUpn6Dcw==",
+      "dev": true,
+      "requires": {
+        "argv": "0.0.2",
+        "ignore-walk": "3.0.3",
+        "js-yaml": "3.14.0",
+        "teeny-request": "6.0.1",
+        "urlgrey": "0.4.4"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "urlgrey": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+          "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+          "dev": true
+        }
+      }
     },
     "codecov.io": {
       "version": "0.1.6",
@@ -458,6 +937,21 @@
         "request": "2.42.0",
         "urlgrey": "0.4.0"
       }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-support": {
       "version": "1.1.3",
@@ -491,6 +985,12 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
       "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "concat-map": {
@@ -853,6 +1353,12 @@
         "ms": "2.0.0"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "deep-equal": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
@@ -864,6 +1370,15 @@
       "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
       "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g=",
       "dev": true
+    },
+    "default-require-extensions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^4.0.0"
+      }
     },
     "defined": {
       "version": "1.0.0",
@@ -981,6 +1496,18 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1027,6 +1554,27 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "find-cache-dir": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
     "foreground-child": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
@@ -1063,6 +1611,12 @@
         "mime": "~1.2.11"
       }
     },
+    "fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1089,6 +1643,24 @@
       "requires": {
         "is-property": "^1.0.0"
       }
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -1121,6 +1693,18 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
+    },
     "har-validator": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
@@ -1151,6 +1735,12 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
     "hash-base": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
@@ -1168,6 +1758,16 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
       }
     },
     "hawk": {
@@ -1201,11 +1801,45 @@
       "dev": true,
       "optional": true
     },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "htmlescape": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "http-signature": {
       "version": "0.10.1",
@@ -1225,10 +1859,64 @@
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "indexof": {
@@ -1284,6 +1972,12 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
     "is-my-json-valid": {
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
@@ -1302,10 +1996,22 @@
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "isarray": {
@@ -1324,6 +2030,160 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^2.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      }
+    },
+    "istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -1351,6 +2211,12 @@
       "dev": true,
       "optional": true
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -1371,6 +2237,23 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -1444,6 +2327,27 @@
         "astw": "^2.0.0"
       }
     },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
@@ -1464,6 +2368,15 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
       }
     },
     "md5.js": {
@@ -1573,6 +2486,21 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
+    "node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "requires": {
+        "process-on-spawn": "^1.0.0"
+      }
+    },
     "node-uuid": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
@@ -1580,2040 +2508,103 @@
       "dev": true
     },
     "nyc": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-6.6.1.tgz",
-      "integrity": "sha1-L2AUYQpXBwAhxMBn6bnjMKI6xqc=",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.1.2",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^1.1.2",
-        "foreground-child": "^1.5.1",
-        "glob": "^7.0.3",
-        "istanbul": "^0.4.3",
-        "md5-hex": "^1.2.0",
-        "micromatch": "^2.3.7",
-        "mkdirp": "^0.5.0",
-        "pkg-up": "^1.0.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.5.0",
-        "signal-exit": "^3.0.0",
-        "source-map": "^0.5.3",
-        "spawn-wrap": "^1.2.2",
-        "test-exclude": "^1.1.0",
-        "yargs": "^4.7.0"
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
       },
       "dependencies": {
-        "append-transform": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "default-require-extensions": "^1.0.0"
-          }
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "caching-transform": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
-          },
-          "dependencies": {
-            "write-file-atomic": {
-              "version": "1.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
-              },
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.4",
-                  "bundled": true,
-                  "dev": true
-                },
-                "imurmurhash": {
-                  "version": "0.1.4",
-                  "bundled": true,
-                  "dev": true
-                },
-                "slide": {
-                  "version": "1.1.6",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
         "convert-source-map": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "default-require-extensions": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
           "dev": true,
           "requires": {
-            "strip-bom": "^2.0.0"
-          },
-          "dependencies": {
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-utf8": "^0.2.0"
-              },
-              "dependencies": {
-                "is-utf8": {
-                  "version": "0.2.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
+            "safe-buffer": "~5.1.1"
           }
         },
-        "find-cache-dir": {
-          "version": "0.1.1",
-          "bundled": true,
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
-          },
-          "dependencies": {
-            "commondir": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "pkg-dir": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "^1.0.0"
-              }
-            }
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pinkie-promise": "^2.0.0"
-              }
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pinkie": "^2.0.0"
-              },
-              "dependencies": {
-                "pinkie": {
-                  "version": "2.0.4",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "foreground-child": {
-          "version": "1.5.1",
-          "bundled": true,
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+          "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
           "dev": true,
           "requires": {
-            "cross-spawn-async": "^2.1.1",
-            "signal-exit": "^2.0.0",
-            "which": "^1.2.1"
-          },
-          "dependencies": {
-            "cross-spawn-async": {
-              "version": "2.2.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^4.0.0",
-                "which": "^1.2.8"
-              },
-              "dependencies": {
-                "lru-cache": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "pseudomap": "^1.0.1",
-                    "yallist": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "pseudomap": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "yallist": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "signal-exit": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "which": {
-              "version": "1.2.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "^1.1.1"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
+            "cross-spawn": "^7.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "glob": {
-          "version": "7.0.3",
-          "bundled": true,
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
+            "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "2 || 3",
+            "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          },
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.0.0"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "^0.4.1",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
-        "istanbul": {
-          "version": "0.4.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "abbrev": "1.0.x",
-            "async": "1.x",
-            "escodegen": "1.8.x",
-            "esprima": "2.7.x",
-            "fileset": "0.2.x",
-            "handlebars": "^4.0.1",
-            "js-yaml": "3.x",
-            "mkdirp": "0.5.x",
-            "nopt": "3.x",
-            "once": "1.x",
-            "resolve": "1.1.x",
-            "supports-color": "^3.1.0",
-            "which": "^1.1.1",
-            "wordwrap": "^1.0.0"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.7",
-              "bundled": true,
-              "dev": true
-            },
-            "async": {
-              "version": "1.5.2",
-              "bundled": true,
-              "dev": true
-            },
-            "escodegen": {
-              "version": "1.8.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "esprima": "^2.7.1",
-                "estraverse": "^1.9.1",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.2.0"
-              },
-              "dependencies": {
-                "estraverse": {
-                  "version": "1.9.3",
-                  "bundled": true,
-                  "dev": true
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "optionator": {
-                  "version": "0.8.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "deep-is": "~0.1.3",
-                    "fast-levenshtein": "^1.1.0",
-                    "levn": "~0.3.0",
-                    "prelude-ls": "~1.1.2",
-                    "type-check": "~0.3.2",
-                    "wordwrap": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "deep-is": {
-                      "version": "0.1.3",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "fast-levenshtein": {
-                      "version": "1.1.3",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "levn": {
-                      "version": "0.3.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
-                      }
-                    },
-                    "prelude-ls": {
-                      "version": "1.1.2",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "type-check": {
-                      "version": "0.3.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "prelude-ls": "~1.1.2"
-                      }
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "amdefine": ">=0.0.4"
-                  },
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "esprima": {
-              "version": "2.7.2",
-              "bundled": true,
-              "dev": true
-            },
-            "fileset": {
-              "version": "0.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "5.x",
-                "minimatch": "2.x"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "2 || 3",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.4",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "balanced-match": "^0.4.1",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.1",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "handlebars": {
-              "version": "4.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "async": "^1.4.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.4.4",
-                "uglify-js": "^2.6"
-              },
-              "dependencies": {
-                "optimist": {
-                  "version": "0.6.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "minimist": "~0.0.1",
-                    "wordwrap": "~0.0.2"
-                  },
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.10",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.4.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "amdefine": ">=0.0.4"
-                  },
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "uglify-js": {
-                  "version": "2.6.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "async": "~0.2.6",
-                    "source-map": "~0.5.1",
-                    "uglify-to-browserify": "~1.0.0",
-                    "yargs": "~3.10.0"
-                  },
-                  "dependencies": {
-                    "async": {
-                      "version": "0.2.10",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    },
-                    "source-map": {
-                      "version": "0.5.6",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    },
-                    "uglify-to-browserify": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    },
-                    "yargs": {
-                      "version": "3.10.0",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "camelcase": "^1.0.2",
-                        "cliui": "^2.1.0",
-                        "decamelize": "^1.0.0",
-                        "window-size": "0.1.0"
-                      },
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true
-                        },
-                        "cliui": {
-                          "version": "2.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "center-align": "^0.1.1",
-                            "right-align": "^0.1.1",
-                            "wordwrap": "0.0.2"
-                          },
-                          "dependencies": {
-                            "center-align": {
-                              "version": "0.1.3",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "align-text": "^0.1.3",
-                                "lazy-cache": "^1.0.3"
-                              },
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "bundled": true,
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "kind-of": "^3.0.2",
-                                    "longest": "^1.0.1",
-                                    "repeat-string": "^1.5.2"
-                                  },
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.0.3",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true,
-                                      "requires": {
-                                        "is-buffer": "^1.0.2"
-                                      },
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.3",
-                                          "bundled": true,
-                                          "dev": true,
-                                          "optional": true
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "lazy-cache": {
-                                  "version": "1.0.4",
-                                  "bundled": true,
-                                  "dev": true,
-                                  "optional": true
-                                }
-                              }
-                            },
-                            "right-align": {
-                              "version": "0.1.3",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "align-text": "^0.1.1"
-                              },
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "bundled": true,
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "kind-of": "^3.0.2",
-                                    "longest": "^1.0.1",
-                                    "repeat-string": "^1.5.2"
-                                  },
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.0.3",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true,
-                                      "requires": {
-                                        "is-buffer": "^1.0.2"
-                                      },
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.3",
-                                          "bundled": true,
-                                          "dev": true,
-                                          "optional": true
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "wordwrap": {
-                              "version": "0.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true
-                        },
-                        "window-size": {
-                          "version": "0.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "js-yaml": {
-              "version": "3.6.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^2.6.0"
-              },
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.7",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "sprintf-js": "~1.0.2"
-                  },
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "abbrev": "1"
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "resolve": {
-              "version": "1.1.7",
-              "bundled": true,
-              "dev": true
-            },
-            "supports-color": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has-flag": "^1.0.0"
-              },
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "^1.1.1"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "md5-hex": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "^0.1.1"
-          },
-          "dependencies": {
-            "md5-o-matic": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "micromatch": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          },
-          "dependencies": {
-            "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "arr-flatten": "^1.0.1"
-              },
-              "dependencies": {
-                "arr-flatten": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "braces": {
-              "version": "1.8.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
-              },
-              "dependencies": {
-                "expand-range": {
-                  "version": "1.8.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "fill-range": "^2.1.0"
-                  },
-                  "dependencies": {
-                    "fill-range": {
-                      "version": "2.2.3",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^1.1.3",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
-                      },
-                      "dependencies": {
-                        "is-number": {
-                          "version": "2.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "kind-of": "^3.0.2"
-                          }
-                        },
-                        "isobject": {
-                          "version": "2.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "isarray": "1.0.0"
-                          },
-                          "dependencies": {
-                            "isarray": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "randomatic": {
-                          "version": "1.1.5",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "is-number": "^2.0.2",
-                            "kind-of": "^3.0.2"
-                          }
-                        },
-                        "repeat-string": {
-                          "version": "1.5.4",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "preserve": {
-                  "version": "0.2.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "repeat-element": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-posix-bracket": "^0.1.0"
-              },
-              "dependencies": {
-                "is-posix-bracket": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
-            "filename-regex": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "3.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.0.2"
-              },
-              "dependencies": {
-                "is-buffer": {
-                  "version": "1.1.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "normalize-path": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "object.omit": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "for-own": "^0.1.3",
-                "is-extendable": "^0.1.1"
-              },
-              "dependencies": {
-                "for-own": {
-                  "version": "0.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "for-in": "^0.1.5"
-                  },
-                  "dependencies": {
-                    "for-in": {
-                      "version": "0.1.5",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "is-extendable": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
-              },
-              "dependencies": {
-                "glob-base": {
-                  "version": "0.3.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "glob-parent": "^2.0.0",
-                    "is-glob": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "glob-parent": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-glob": "^2.0.0"
-                      }
-                    }
-                  }
-                },
-                "is-dotfile": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "regex-cache": {
-              "version": "0.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-equal-shallow": "^0.1.3",
-                "is-primitive": "^2.0.0"
-              },
-              "dependencies": {
-                "is-equal-shallow": {
-                  "version": "0.1.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-primitive": "^2.0.0"
-                  }
-                },
-                "is-primitive": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "pkg-up": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0"
-          }
-        },
-        "resolve-from": {
+        "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
-        },
-        "rimraf": {
-          "version": "2.5.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.0"
-          }
         },
         "signal-exit": {
-          "version": "3.0.0",
-          "bundled": true,
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
           "dev": true
         },
-        "source-map": {
-          "version": "0.5.6",
-          "bundled": true,
-          "dev": true
-        },
-        "spawn-wrap": {
-          "version": "1.2.3",
-          "bundled": true,
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
-            "foreground-child": "^1.3.3",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.3.3",
-            "signal-exit": "^2.0.0",
-            "which": "^1.2.4"
-          },
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "signal-exit": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "which": {
-              "version": "1.2.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "^1.1.1"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "test-exclude": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "lodash.assign": "^4.0.9",
-            "micromatch": "^2.3.8",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
-          },
-          "dependencies": {
-            "lodash.assign": {
-              "version": "4.0.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lodash.keys": "^4.0.0",
-                "lodash.rest": "^4.0.0"
-              },
-              "dependencies": {
-                "lodash.keys": {
-                  "version": "4.0.7",
-                  "bundled": true,
-                  "dev": true
-                },
-                "lodash.rest": {
-                  "version": "4.0.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
-              },
-              "dependencies": {
-                "read-pkg": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "load-json-file": "^1.0.0",
-                    "normalize-package-data": "^2.3.2",
-                    "path-type": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "load-json-file": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.4",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "error-ex": "^1.2.0"
-                          },
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "is-arrayish": "^0.2.1"
-                              },
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "strip-bom": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "is-utf8": "^0.2.0"
-                          },
-                          "dependencies": {
-                            "is-utf8": {
-                              "version": "0.2.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "normalize-package-data": {
-                      "version": "2.3.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
-                      },
-                      "dependencies": {
-                        "hosted-git-info": {
-                          "version": "2.1.5",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "is-builtin-module": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "builtin-modules": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "builtin-modules": {
-                              "version": "1.1.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "semver": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "validate-npm-package-license": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "spdx-correct": "~1.0.0",
-                            "spdx-expression-parse": "~1.0.0"
-                          },
-                          "dependencies": {
-                            "spdx-correct": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "spdx-license-ids": "^1.0.2"
-                              },
-                              "dependencies": {
-                                "spdx-license-ids": {
-                                  "version": "1.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "spdx-expression-parse": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "spdx-exceptions": "^1.0.4",
-                                "spdx-license-ids": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "spdx-exceptions": {
-                                  "version": "1.0.4",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "spdx-license-ids": {
-                                  "version": "1.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "path-type": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.4",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "yargs": {
-          "version": "4.7.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "pkg-conf": "^1.1.2",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^1.0.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cliui": {
-              "version": "3.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
-              },
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "wrap-ansi": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "string-width": "^1.0.1"
-                  }
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.assign": {
-              "version": "4.0.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lodash.keys": "^4.0.0",
-                "lodash.rest": "^4.0.0"
-              },
-              "dependencies": {
-                "lodash.keys": {
-                  "version": "4.0.7",
-                  "bundled": true,
-                  "dev": true
-                },
-                "lodash.rest": {
-                  "version": "4.0.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lcid": "^1.0.0"
-              },
-              "dependencies": {
-                "lcid": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "invert-kv": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "invert-kv": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "pkg-conf": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "^1.0.0",
-                "load-json-file": "^1.1.0",
-                "object-assign": "^4.0.1",
-                "symbol": "^0.2.1"
-              },
-              "dependencies": {
-                "load-json-file": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "parse-json": "^2.2.0",
-                    "pify": "^2.0.0",
-                    "pinkie-promise": "^2.0.0",
-                    "strip-bom": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.4",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "parse-json": {
-                      "version": "2.2.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "error-ex": "^1.2.0"
-                      },
-                      "dependencies": {
-                        "error-ex": {
-                          "version": "1.3.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "is-arrayish": "^0.2.1"
-                          },
-                          "dependencies": {
-                            "is-arrayish": {
-                              "version": "0.2.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "pify": {
-                      "version": "2.3.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "pinkie": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "strip-bom": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-utf8": "^0.2.0"
-                      },
-                      "dependencies": {
-                        "is-utf8": {
-                          "version": "0.2.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "symbol": {
-                  "version": "0.2.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
-              },
-              "dependencies": {
-                "read-pkg": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "load-json-file": "^1.0.0",
-                    "normalize-package-data": "^2.3.2",
-                    "path-type": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "load-json-file": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.4",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "error-ex": "^1.2.0"
-                          },
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "is-arrayish": "^0.2.1"
-                              },
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "strip-bom": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "is-utf8": "^0.2.0"
-                          },
-                          "dependencies": {
-                            "is-utf8": {
-                              "version": "0.2.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "normalize-package-data": {
-                      "version": "2.3.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
-                      },
-                      "dependencies": {
-                        "hosted-git-info": {
-                          "version": "2.1.5",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "is-builtin-module": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "builtin-modules": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "builtin-modules": {
-                              "version": "1.1.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "semver": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "validate-npm-package-license": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "spdx-correct": "~1.0.0",
-                            "spdx-expression-parse": "~1.0.0"
-                          },
-                          "dependencies": {
-                            "spdx-correct": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "spdx-license-ids": "^1.0.2"
-                              },
-                              "dependencies": {
-                                "spdx-license-ids": {
-                                  "version": "1.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "spdx-expression-parse": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "spdx-exceptions": "^1.0.4",
-                                "spdx-license-ids": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "spdx-exceptions": {
-                                  "version": "1.0.4",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "spdx-license-ids": {
-                                  "version": "1.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "path-type": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.4",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "set-blocking": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "window-size": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "yargs-parser": {
-              "version": "2.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "camelcase": "^2.1.1",
-                "lodash.assign": "^4.0.6"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -3641,9 +2632,9 @@
       "dev": true
     },
     "opener": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true
     },
     "os-browserify": {
@@ -3651,6 +2642,51 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
       "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
       "dev": true
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
     },
     "pako": {
       "version": "0.2.9",
@@ -3686,10 +2722,22 @@
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-parse": {
@@ -3732,6 +2780,15 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -3743,6 +2800,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
+    },
+    "process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "dev": true,
+      "requires": {
+        "fromentries": "^1.2.0"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -3841,6 +2907,15 @@
         }
       }
     },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
+    },
     "request": {
       "version": "2.42.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
@@ -3864,6 +2939,18 @@
         "tunnel-agent": "~0.4.0"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
@@ -3873,6 +2960,12 @@
         "path-parse": "^1.0.5"
       }
     },
+    "resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true
+    },
     "resumer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
@@ -3880,6 +2973,31 @@
       "dev": true,
       "requires": {
         "through": "~2.3.4"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ripemd160": {
@@ -3896,6 +3014,18 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "sha.js": {
@@ -3917,6 +3047,21 @@
         "json-stable-stringify": "~0.0.0",
         "sha.js": "~2.4.4"
       }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
     },
     "shell-quote": {
       "version": "1.6.1",
@@ -3951,6 +3096,64 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "foreground-child": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+          "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "split": {
       "version": "0.2.10",
@@ -4032,6 +3235,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
+      "requires": {
+        "stubs": "^3.0.0"
+      }
+    },
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
@@ -4055,6 +3267,34 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -4075,6 +3315,18 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
+    },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true
+    },
+    "stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
+      "dev": true
     },
     "subarg": {
       "version": "1.0.0",
@@ -4125,6 +3377,2047 @@
         "tap-mocha-reporter": "0.0 || 1",
         "tap-parser": "^1.2.2",
         "tmatch": "^2.0.1"
+      },
+      "dependencies": {
+        "nyc": {
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/nyc/-/nyc-6.6.1.tgz",
+          "integrity": "sha1-L2AUYQpXBwAhxMBn6bnjMKI6xqc=",
+          "dev": true,
+          "requires": {
+            "append-transform": "^0.4.0",
+            "arrify": "^1.0.1",
+            "caching-transform": "^1.0.0",
+            "convert-source-map": "^1.1.2",
+            "default-require-extensions": "^1.0.0",
+            "find-cache-dir": "^0.1.1",
+            "find-up": "^1.1.2",
+            "foreground-child": "^1.5.1",
+            "glob": "^7.0.3",
+            "istanbul": "^0.4.3",
+            "md5-hex": "^1.2.0",
+            "micromatch": "^2.3.7",
+            "mkdirp": "^0.5.0",
+            "pkg-up": "^1.0.0",
+            "resolve-from": "^2.0.0",
+            "rimraf": "^2.5.0",
+            "signal-exit": "^3.0.0",
+            "source-map": "^0.5.3",
+            "spawn-wrap": "^1.2.2",
+            "test-exclude": "^1.1.0",
+            "yargs": "^4.7.0"
+          },
+          "dependencies": {
+            "append-transform": {
+              "version": "0.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "default-require-extensions": "^1.0.0"
+              }
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "caching-transform": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "md5-hex": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "write-file-atomic": "^1.1.4"
+              },
+              "dependencies": {
+                "write-file-atomic": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "^4.1.2",
+                    "imurmurhash": "^0.1.4",
+                    "slide": "^1.1.5"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.4",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "imurmurhash": {
+                      "version": "0.1.4",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "slide": {
+                      "version": "1.1.6",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "convert-source-map": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "default-require-extensions": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "strip-bom": "^2.0.0"
+              },
+              "dependencies": {
+                "strip-bom": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-utf8": "^0.2.0"
+                  },
+                  "dependencies": {
+                    "is-utf8": {
+                      "version": "0.2.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "find-cache-dir": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pkg-dir": "^1.0.0"
+              },
+              "dependencies": {
+                "commondir": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "pkg-dir": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "find-up": "^1.0.0"
+                  }
+                }
+              }
+            },
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              },
+              "dependencies": {
+                "path-exists": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "pinkie-promise": "^2.0.0"
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "pinkie": "^2.0.0"
+                  },
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "foreground-child": {
+              "version": "1.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cross-spawn-async": "^2.1.1",
+                "signal-exit": "^2.0.0",
+                "which": "^1.2.1"
+              },
+              "dependencies": {
+                "cross-spawn-async": {
+                  "version": "2.2.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "^4.0.0",
+                    "which": "^1.2.8"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "4.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "pseudomap": "^1.0.1",
+                        "yallist": "^2.0.0"
+                      },
+                      "dependencies": {
+                        "pseudomap": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "yallist": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "signal-exit": {
+                  "version": "2.1.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "which": {
+                  "version": "1.2.10",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "isexe": "^1.1.1"
+                  },
+                  "dependencies": {
+                    "isexe": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "glob": {
+              "version": "7.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              },
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "once": "^1.3.0",
+                    "wrappy": "1"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.0.0"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "^0.4.1",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.1",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "istanbul": {
+              "version": "0.4.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "abbrev": "1.0.x",
+                "async": "1.x",
+                "escodegen": "1.8.x",
+                "esprima": "2.7.x",
+                "fileset": "0.2.x",
+                "handlebars": "^4.0.1",
+                "js-yaml": "3.x",
+                "mkdirp": "0.5.x",
+                "nopt": "3.x",
+                "once": "1.x",
+                "resolve": "1.1.x",
+                "supports-color": "^3.1.0",
+                "which": "^1.1.1",
+                "wordwrap": "^1.0.0"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "bundled": true,
+                  "dev": true
+                },
+                "async": {
+                  "version": "1.5.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "escodegen": {
+                  "version": "1.8.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "esprima": "^2.7.1",
+                    "estraverse": "^1.9.1",
+                    "esutils": "^2.0.2",
+                    "optionator": "^0.8.1",
+                    "source-map": "~0.2.0"
+                  },
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "1.9.3",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "optionator": {
+                      "version": "0.8.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "deep-is": "~0.1.3",
+                        "fast-levenshtein": "^1.1.0",
+                        "levn": "~0.3.0",
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2",
+                        "wordwrap": "~1.0.0"
+                      },
+                      "dependencies": {
+                        "deep-is": {
+                          "version": "0.1.3",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "fast-levenshtein": {
+                          "version": "1.1.3",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "levn": {
+                          "version": "0.3.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "prelude-ls": "~1.1.2",
+                            "type-check": "~0.3.2"
+                          }
+                        },
+                        "prelude-ls": {
+                          "version": "1.1.2",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "type-check": {
+                          "version": "0.3.2",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "prelude-ls": "~1.1.2"
+                          }
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "amdefine": ">=0.0.4"
+                      },
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.7.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "fileset": {
+                  "version": "0.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "glob": "5.x",
+                    "minimatch": "2.x"
+                  },
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                      },
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.5",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "once": "^1.3.0",
+                            "wrappy": "1"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "brace-expansion": "^1.0.0"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.4",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "balanced-match": "^0.4.1",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.1",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "handlebars": {
+                  "version": "4.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "async": "^1.4.0",
+                    "optimist": "^0.6.1",
+                    "source-map": "^0.4.4",
+                    "uglify-js": "^2.6"
+                  },
+                  "dependencies": {
+                    "optimist": {
+                      "version": "0.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "minimist": "~0.0.1",
+                        "wordwrap": "~0.0.2"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.10",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.4.4",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "amdefine": ">=0.0.4"
+                      },
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "uglify-js": {
+                      "version": "2.6.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "async": "~0.2.6",
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
+                      },
+                      "dependencies": {
+                        "async": {
+                          "version": "0.2.10",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "source-map": {
+                          "version": "0.5.6",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "uglify-to-browserify": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "yargs": {
+                          "version": "3.10.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "camelcase": "^1.0.2",
+                            "cliui": "^2.1.0",
+                            "decamelize": "^1.0.0",
+                            "window-size": "0.1.0"
+                          },
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "cliui": {
+                              "version": "2.1.0",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "center-align": "^0.1.1",
+                                "right-align": "^0.1.1",
+                                "wordwrap": "0.0.2"
+                              },
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.3",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "align-text": "^0.1.3",
+                                    "lazy-cache": "^1.0.3"
+                                  },
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "bundled": true,
+                                      "dev": true,
+                                      "optional": true,
+                                      "requires": {
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
+                                      },
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.3",
+                                          "bundled": true,
+                                          "dev": true,
+                                          "optional": true,
+                                          "requires": {
+                                            "is-buffer": "^1.0.2"
+                                          },
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.3",
+                                              "bundled": true,
+                                              "dev": true,
+                                              "optional": true
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "bundled": true,
+                                          "dev": true,
+                                          "optional": true
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "bundled": true,
+                                          "dev": true,
+                                          "optional": true
+                                        }
+                                      }
+                                    },
+                                    "lazy-cache": {
+                                      "version": "1.0.4",
+                                      "bundled": true,
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "align-text": "^0.1.1"
+                                  },
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "bundled": true,
+                                      "dev": true,
+                                      "optional": true,
+                                      "requires": {
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
+                                      },
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.3",
+                                          "bundled": true,
+                                          "dev": true,
+                                          "optional": true,
+                                          "requires": {
+                                            "is-buffer": "^1.0.2"
+                                          },
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.3",
+                                              "bundled": true,
+                                              "dev": true,
+                                              "optional": true
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "bundled": true,
+                                          "dev": true,
+                                          "optional": true
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "bundled": true,
+                                          "dev": true,
+                                          "optional": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "window-size": {
+                              "version": "0.1.0",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "js-yaml": {
+                  "version": "3.6.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "argparse": "^1.0.7",
+                    "esprima": "^2.6.0"
+                  },
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.7",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "sprintf-js": "~1.0.2"
+                      },
+                      "dependencies": {
+                        "sprintf-js": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "abbrev": "1"
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "resolve": {
+                  "version": "1.1.7",
+                  "bundled": true,
+                  "dev": true
+                },
+                "supports-color": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^1.0.0"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.2.10",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "isexe": "^1.1.1"
+                  },
+                  "dependencies": {
+                    "isexe": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "wordwrap": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "md5-o-matic": "^0.1.1"
+              },
+              "dependencies": {
+                "md5-o-matic": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "micromatch": {
+              "version": "2.3.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              },
+              "dependencies": {
+                "arr-diff": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "arr-flatten": "^1.0.1"
+                  },
+                  "dependencies": {
+                    "arr-flatten": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "array-unique": {
+                  "version": "0.2.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "braces": {
+                  "version": "1.8.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "expand-range": "^1.8.1",
+                    "preserve": "^0.2.0",
+                    "repeat-element": "^1.1.2"
+                  },
+                  "dependencies": {
+                    "expand-range": {
+                      "version": "1.8.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "fill-range": "^2.1.0"
+                      },
+                      "dependencies": {
+                        "fill-range": {
+                          "version": "2.2.3",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "is-number": "^2.1.0",
+                            "isobject": "^2.0.0",
+                            "randomatic": "^1.1.3",
+                            "repeat-element": "^1.1.2",
+                            "repeat-string": "^1.5.2"
+                          },
+                          "dependencies": {
+                            "is-number": {
+                              "version": "2.1.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "kind-of": "^3.0.2"
+                              }
+                            },
+                            "isobject": {
+                              "version": "2.1.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "isarray": "1.0.0"
+                              },
+                              "dependencies": {
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "randomatic": {
+                              "version": "1.1.5",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "is-number": "^2.0.2",
+                                "kind-of": "^3.0.2"
+                              }
+                            },
+                            "repeat-string": {
+                              "version": "1.5.4",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "preserve": {
+                      "version": "0.2.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "repeat-element": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-posix-bracket": "^0.1.0"
+                  },
+                  "dependencies": {
+                    "is-posix-bracket": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "extglob": {
+                  "version": "0.3.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extglob": "^1.0.0"
+                  }
+                },
+                "filename-regex": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extglob": "^1.0.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "3.0.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.0.2"
+                  },
+                  "dependencies": {
+                    "is-buffer": {
+                      "version": "1.1.3",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "normalize-path": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "object.omit": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "for-own": "^0.1.3",
+                    "is-extendable": "^0.1.1"
+                  },
+                  "dependencies": {
+                    "for-own": {
+                      "version": "0.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "for-in": "^0.1.5"
+                      },
+                      "dependencies": {
+                        "for-in": {
+                          "version": "0.1.5",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "is-extendable": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "parse-glob": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "glob-base": "^0.3.0",
+                    "is-dotfile": "^1.0.0",
+                    "is-extglob": "^1.0.0",
+                    "is-glob": "^2.0.0"
+                  },
+                  "dependencies": {
+                    "glob-base": {
+                      "version": "0.3.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "glob-parent": "^2.0.0",
+                        "is-glob": "^2.0.0"
+                      },
+                      "dependencies": {
+                        "glob-parent": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "is-glob": "^2.0.0"
+                          }
+                        }
+                      }
+                    },
+                    "is-dotfile": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "regex-cache": {
+                  "version": "0.4.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-equal-shallow": "^0.1.3",
+                    "is-primitive": "^2.0.0"
+                  },
+                  "dependencies": {
+                    "is-equal-shallow": {
+                      "version": "0.1.3",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-primitive": "^2.0.0"
+                      }
+                    },
+                    "is-primitive": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "pkg-up": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "find-up": "^1.0.0"
+              }
+            },
+            "resolve-from": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "^7.0.0"
+              }
+            },
+            "signal-exit": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "bundled": true,
+              "dev": true
+            },
+            "spawn-wrap": {
+              "version": "1.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "foreground-child": "^1.3.3",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.3.3",
+                "signal-exit": "^2.0.0",
+                "which": "^1.2.4"
+              },
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "signal-exit": {
+                  "version": "2.1.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "which": {
+                  "version": "1.2.10",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "isexe": "^1.1.1"
+                  },
+                  "dependencies": {
+                    "isexe": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "test-exclude": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arrify": "^1.0.1",
+                "lodash.assign": "^4.0.9",
+                "micromatch": "^2.3.8",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1"
+              },
+              "dependencies": {
+                "lodash.assign": {
+                  "version": "4.0.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash.keys": "^4.0.0",
+                    "lodash.rest": "^4.0.0"
+                  },
+                  "dependencies": {
+                    "lodash.keys": {
+                      "version": "4.0.7",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "lodash.rest": {
+                      "version": "4.0.3",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "find-up": "^1.0.0",
+                    "read-pkg": "^1.0.0"
+                  },
+                  "dependencies": {
+                    "read-pkg": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
+                      },
+                      "dependencies": {
+                        "load-json-file": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "graceful-fs": "^4.1.2",
+                            "parse-json": "^2.2.0",
+                            "pify": "^2.0.0",
+                            "pinkie-promise": "^2.0.0",
+                            "strip-bom": "^2.0.0"
+                          },
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.4",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "parse-json": {
+                              "version": "2.2.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "error-ex": "^1.2.0"
+                              },
+                              "dependencies": {
+                                "error-ex": {
+                                  "version": "1.3.0",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "requires": {
+                                    "is-arrayish": "^0.2.1"
+                                  },
+                                  "dependencies": {
+                                    "is-arrayish": {
+                                      "version": "0.2.1",
+                                      "bundled": true,
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "pinkie": "^2.0.0"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "strip-bom": {
+                              "version": "2.0.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "is-utf8": "^0.2.0"
+                              },
+                              "dependencies": {
+                                "is-utf8": {
+                                  "version": "0.2.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "normalize-package-data": {
+                          "version": "2.3.5",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "hosted-git-info": "^2.1.4",
+                            "is-builtin-module": "^1.0.0",
+                            "semver": "2 || 3 || 4 || 5",
+                            "validate-npm-package-license": "^3.0.1"
+                          },
+                          "dependencies": {
+                            "hosted-git-info": {
+                              "version": "2.1.5",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "is-builtin-module": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "builtin-modules": "^1.0.0"
+                              },
+                              "dependencies": {
+                                "builtin-modules": {
+                                  "version": "1.1.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.1.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "validate-npm-package-license": {
+                              "version": "3.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "spdx-correct": "~1.0.0",
+                                "spdx-expression-parse": "~1.0.0"
+                              },
+                              "dependencies": {
+                                "spdx-correct": {
+                                  "version": "1.0.2",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "requires": {
+                                    "spdx-license-ids": "^1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "spdx-license-ids": {
+                                      "version": "1.2.1",
+                                      "bundled": true,
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "spdx-expression-parse": {
+                                  "version": "1.0.2",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "requires": {
+                                    "spdx-exceptions": "^1.0.4",
+                                    "spdx-license-ids": "^1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "spdx-exceptions": {
+                                      "version": "1.0.4",
+                                      "bundled": true,
+                                      "dev": true
+                                    },
+                                    "spdx-license-ids": {
+                                      "version": "1.2.1",
+                                      "bundled": true,
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-type": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "graceful-fs": "^4.1.2",
+                            "pify": "^2.0.0",
+                            "pinkie-promise": "^2.0.0"
+                          },
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.4",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "pinkie": "^2.0.0"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "yargs": {
+              "version": "4.7.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "lodash.assign": "^4.0.3",
+                "os-locale": "^1.4.0",
+                "pkg-conf": "^1.1.2",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^1.0.0",
+                "string-width": "^1.0.1",
+                "window-size": "^0.2.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^2.4.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "cliui": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wrap-ansi": "^2.0.0"
+                  },
+                  "dependencies": {
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "^2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "wrap-ansi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "string-width": "^1.0.1"
+                      }
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "lodash.assign": {
+                  "version": "4.0.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash.keys": "^4.0.0",
+                    "lodash.rest": "^4.0.0"
+                  },
+                  "dependencies": {
+                    "lodash.keys": {
+                      "version": "4.0.7",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "lodash.rest": {
+                      "version": "4.0.3",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "os-locale": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lcid": "^1.0.0"
+                  },
+                  "dependencies": {
+                    "lcid": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "invert-kv": "^1.0.0"
+                      },
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "pkg-conf": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "find-up": "^1.0.0",
+                    "load-json-file": "^1.1.0",
+                    "object-assign": "^4.0.1",
+                    "symbol": "^0.2.1"
+                  },
+                  "dependencies": {
+                    "load-json-file": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.4",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "parse-json": {
+                          "version": "2.2.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "error-ex": "^1.2.0"
+                          },
+                          "dependencies": {
+                            "error-ex": {
+                              "version": "1.3.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "is-arrayish": "^0.2.1"
+                              },
+                              "dependencies": {
+                                "is-arrayish": {
+                                  "version": "0.2.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "^2.0.0"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "strip-bom": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "is-utf8": "^0.2.0"
+                          },
+                          "dependencies": {
+                            "is-utf8": {
+                              "version": "0.2.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "symbol": {
+                      "version": "0.2.3",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "find-up": "^1.0.0",
+                    "read-pkg": "^1.0.0"
+                  },
+                  "dependencies": {
+                    "read-pkg": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
+                      },
+                      "dependencies": {
+                        "load-json-file": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "graceful-fs": "^4.1.2",
+                            "parse-json": "^2.2.0",
+                            "pify": "^2.0.0",
+                            "pinkie-promise": "^2.0.0",
+                            "strip-bom": "^2.0.0"
+                          },
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.4",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "parse-json": {
+                              "version": "2.2.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "error-ex": "^1.2.0"
+                              },
+                              "dependencies": {
+                                "error-ex": {
+                                  "version": "1.3.0",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "requires": {
+                                    "is-arrayish": "^0.2.1"
+                                  },
+                                  "dependencies": {
+                                    "is-arrayish": {
+                                      "version": "0.2.1",
+                                      "bundled": true,
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "pinkie": "^2.0.0"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "strip-bom": {
+                              "version": "2.0.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "is-utf8": "^0.2.0"
+                              },
+                              "dependencies": {
+                                "is-utf8": {
+                                  "version": "0.2.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "normalize-package-data": {
+                          "version": "2.3.5",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "hosted-git-info": "^2.1.4",
+                            "is-builtin-module": "^1.0.0",
+                            "semver": "2 || 3 || 4 || 5",
+                            "validate-npm-package-license": "^3.0.1"
+                          },
+                          "dependencies": {
+                            "hosted-git-info": {
+                              "version": "2.1.5",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "is-builtin-module": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "builtin-modules": "^1.0.0"
+                              },
+                              "dependencies": {
+                                "builtin-modules": {
+                                  "version": "1.1.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.1.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "validate-npm-package-license": {
+                              "version": "3.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "spdx-correct": "~1.0.0",
+                                "spdx-expression-parse": "~1.0.0"
+                              },
+                              "dependencies": {
+                                "spdx-correct": {
+                                  "version": "1.0.2",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "requires": {
+                                    "spdx-license-ids": "^1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "spdx-license-ids": {
+                                      "version": "1.2.1",
+                                      "bundled": true,
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "spdx-expression-parse": {
+                                  "version": "1.0.2",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "requires": {
+                                    "spdx-exceptions": "^1.0.4",
+                                    "spdx-license-ids": "^1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "spdx-exceptions": {
+                                      "version": "1.0.4",
+                                      "bundled": true,
+                                      "dev": true
+                                    },
+                                    "spdx-license-ids": {
+                                      "version": "1.2.1",
+                                      "bundled": true,
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-type": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "graceful-fs": "^4.1.2",
+                            "pify": "^2.0.0",
+                            "pinkie-promise": "^2.0.0"
+                          },
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.4",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "pinkie": "^2.0.0"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "set-blocking": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "string-width": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  },
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "number-is-nan": "^1.0.0"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "number-is-nan": "^1.0.0"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "^2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "window-size": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "yargs-parser": {
+                  "version": "2.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "camelcase": "^2.1.1",
+                    "lodash.assign": "^4.0.6"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "2.1.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "tap-mocha-reporter": {
@@ -4202,6 +5495,54 @@
         }
       }
     },
+    "teeny-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
+      "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^4.0.0",
+        "node-fetch": "^2.2.0",
+        "stream-events": "^1.0.5",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
+      }
+    },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -4239,6 +5580,12 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
@@ -4267,11 +5614,26 @@
       "dev": true,
       "optional": true
     },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "uglify-js": {
       "version": "3.12.1",
@@ -4390,11 +5752,89 @@
         }
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+          "dev": true
+        }
+      }
     },
     "xtend": {
       "version": "4.0.1",
@@ -4402,11 +5842,46 @@
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
+    "y18n": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "dev": true
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "@mapbox/sphericalmercator": "~1.1.0"
   },
   "scripts": {
-    "test": "tap test/*.js",
-    "build": "browserify -s geoViewport index.js | uglifyjs -c > geo-viewport.js"
+    "test": "nyc tap test/*.js",
+    "build": "browserify -s geoViewport index.js | uglifyjs -c > geo-viewport.js",
+    "coverage": "nyc report --reporter html && opener coverage/index.html",
+    "upload-coverage": "nyc report --reporter json && codecov -f ./coverage/coverage-final.json"
   },
   "keywords": [
     "geographic",
@@ -25,10 +27,19 @@
   ],
   "devDependencies": {
     "browserify": "^13.0.0",
+    "codecov": "^3.8.1",
+    "nyc": "^15.1.0",
+    "opener": "^1.5.2",
     "tap": "^5.7.0",
     "uglify-js": "^3.12.1"
   },
   "main": "index.js",
   "homepage": "https://github.com/mapbox/geo-viewport",
-  "description": "convert between viewports and extents"
+  "description": "convert between viewports and extents",
+  "nyc": {
+    "all": true,
+    "include": [
+      "index.js"
+    ]
+  }
 }


### PR DESCRIPTION
Updates `travis.yml` to ensure we're testing against newer versions of Node. Additionally, this PR adds code coverage via `codecov.io` and adds a badge for it.