### PR TITLE
support viewports crossing the antimeridian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.5.0
+
+* Update viewport method to take an optional `allowAntiMeridian` parameter
+
 ## v0.4.0
 
 * Update viewport method to take an optional `allowFloat` parameter to allow float values (h/t @TeaSeaLancs) [#15](https://github.com/mapbox/geo-viewport/pull/15)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ console.log(center);
 
 ## api
 
-### `viewport(bounds, dimensions, minzoom, maxzoom, tileSize, allowFloat)`
+### `viewport(bounds, dimensions, minzoom, maxzoom, tileSize, allowFloat, allowAntiMeridian)`
 
 Given a `WSEN` array of bounds and a `[x, y]` array of pixel dimensions, return a `{ center: [lon, lat], zoom: zoom }` viewport. Use `allowFloat` to retain float values in the output.
 

--- a/index.js
+++ b/index.js
@@ -15,11 +15,12 @@ function fetchMerc(tileSize, allowAntiMeridian) {
     tileSize = tileSize || 256;
     antiMeridian = allowAntiMeridian || false;
 
-    if (!smCache[tileSize]) {
-        smCache[tileSize] = new SphericalMercator({ size: tileSize, antimeridian: antiMeridian });
+    var cacheKey = tileSize + String(antiMeridian);
+    if (!smCache[cacheKey]) {
+        smCache[cacheKey] = new SphericalMercator({ size: tileSize, antimeridian: antiMeridian });
     }
 
-    return smCache[tileSize];
+    return smCache[cacheKey];
 }
 
 function getAdjusted(base, ratios, allowFloat) {

--- a/index.js
+++ b/index.js
@@ -11,11 +11,12 @@ var smCache = {};
 module.exports.viewport = viewport;
 module.exports.bounds = bounds;
 
-function fetchMerc(tileSize) {
+function fetchMerc(tileSize, antiMeridian) {
     tileSize = tileSize || 256;
+    antiMeridian = antiMeridian || false;
 
     if (!smCache[tileSize]) {
-        smCache[tileSize] = new SphericalMercator({ size: tileSize });
+        smCache[tileSize] = new SphericalMercator({ size: tileSize, antimeridian: antiMeridian });
     }
 
     return smCache[tileSize];
@@ -29,10 +30,10 @@ function getAdjusted(base, ratios, allowFloat) {
     return allowFloat ? adjusted : Math.floor(adjusted);
 }
 
-function viewport(bounds, dimensions, minzoom, maxzoom, tileSize, allowFloat) {
+function viewport(bounds, dimensions, minzoom, maxzoom, tileSize, allowFloat, antiMeridian) {
     minzoom = (minzoom === undefined) ? 0 : minzoom;
     maxzoom = (maxzoom === undefined) ? 20 : maxzoom;
-    var merc = fetchMerc(tileSize);
+    var merc = fetchMerc(tileSize, antiMeridian);
     var base = maxzoom;
     var bl = merc.px([bounds[0], bounds[1]], base);
     var tr = merc.px([bounds[2], bounds[3]], base);

--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ var smCache = {};
 module.exports.viewport = viewport;
 module.exports.bounds = bounds;
 
-function fetchMerc(tileSize, antiMeridian) {
+function fetchMerc(tileSize, allowAntiMeridian) {
     tileSize = tileSize || 256;
-    antiMeridian = antiMeridian || false;
+    antiMeridian = allowAntiMeridian || false;
 
     if (!smCache[tileSize]) {
         smCache[tileSize] = new SphericalMercator({ size: tileSize, antimeridian: antiMeridian });
@@ -30,10 +30,10 @@ function getAdjusted(base, ratios, allowFloat) {
     return allowFloat ? adjusted : Math.floor(adjusted);
 }
 
-function viewport(bounds, dimensions, minzoom, maxzoom, tileSize, allowFloat, antiMeridian) {
+function viewport(bounds, dimensions, minzoom, maxzoom, tileSize, allowFloat, allowAntiMeridian) {
     minzoom = (minzoom === undefined) ? 0 : minzoom;
     maxzoom = (maxzoom === undefined) ? 20 : maxzoom;
-    var merc = fetchMerc(tileSize, antiMeridian);
+    var merc = fetchMerc(tileSize, allowAntiMeridian);
     var base = maxzoom;
     var bl = merc.px([bounds[0], bounds[1]], base);
     var tr = merc.px([bounds[2], bounds[3]], base);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geo-viewport",
-  "version": "0.4.1",
+  "version": "0.5.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geo-viewport",
-  "version": "0.5.0-dev",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -332,9 +332,9 @@
       "dev": true
     },
     "@mapbox/sphericalmercator": {
-      "version": "1.2.0-dev",
-      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.2.0-dev.tgz",
-      "integrity": "sha512-EZEaumWyM6lHNP4WlPzUl7ccR953ukgJHm6CKL1yNUdK4b09PE1ziSeUVivBrKRx8PzfOe/h4/dZrcEcIA4tzA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.2.0.tgz",
+      "integrity": "sha512-ZTOuuwGuMOJN+HEmG/68bSEw15HHaMWmQ5gdTsWdWsjDe56K1kGvLOK6bOSC8gWgIvEO0w6un/2Gvv1q5hJSkQ=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -332,9 +332,9 @@
       "dev": true
     },
     "@mapbox/sphericalmercator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz",
-      "integrity": "sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA=="
+      "version": "1.2.0-dev",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.2.0-dev.tgz",
+      "integrity": "sha512-EZEaumWyM6lHNP4WlPzUl7ccR953ukgJHm6CKL1yNUdK4b09PE1ziSeUVivBrKRx8PzfOe/h4/dZrcEcIA4tzA=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "bugs": {
     "url": "https://github.com/mapbox/geo-viewport/issues"
   },
-  "version": "0.5.0-dev",
+  "version": "0.5.0",
   "dependencies": {
-    "@mapbox/sphericalmercator": "^1.2.0-dev"
+    "@mapbox/sphericalmercator": "^1.2.0"
   },
   "scripts": {
     "test": "nyc tap test/*.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/mapbox/geo-viewport/issues"
   },
-  "version": "0.4.1",
+  "version": "0.5.0-dev",
   "dependencies": {
     "@mapbox/sphericalmercator": "^1.2.0-dev"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "version": "0.4.1",
   "dependencies": {
-    "@mapbox/sphericalmercator": "~1.1.0"
+    "@mapbox/sphericalmercator": "^1.2.0-dev"
   },
   "scripts": {
     "test": "nyc tap test/*.js",

--- a/test/viewport.js
+++ b/test/viewport.js
@@ -64,6 +64,20 @@ test('viewport in Southern hemisphere', function(t) {
     t.end();
 });
 
+test('viewport across the antimeridian', function(t) {
+    t.ok(areViewportsApproximatelyEqual(
+        viewport.viewport([175, -43, 190, -43], [300, 200], undefined, undefined, 512, true, false),
+        { center: [177.5000001490116, -43.00000017011762], zoom: 5.398743777929521 }
+    ));
+    
+    t.ok(areViewportsApproximatelyEqual(
+        viewport.viewport([175, -43, 190, -43], [300, 200], undefined, undefined, 512, true, true),
+        { center: [182.50000018626451, -43.00000017011762], zoom: 3.8137812127148685 }
+    ));
+
+    t.end();
+});
+
 test('bounds for 512px tiles', function(t) {
     var bounds = viewport.bounds([-77.036556, 38.897708], 17, [1080, 350], 512);
     var xMin = bounds[0];


### PR DESCRIPTION
Previously, if the `viewport()` method was handed a [w, s, e, n] bounding box that included longitude values >180°, it would return a center coordinate & zoom that clamped to the left of the antimeridian (i.e. ~177°).

This update leverages the change in https://github.com/mapbox/sphericalmercator/pull/44 to expose the new option `allowAntiMeridian` in `viewport()`. When this option is set to `true`, the method will be allowed to return center coordinates with longitude values > 180°. 

cc/ @mapbox/static-apis
